### PR TITLE
fix: correct case-sensitive key against value in .env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     environment:
       TZ: ${Timezone}
       # http://pi.hole/admin password.
-      WEBPASSWORD: ${password}
+      WEBPASSWORD: ${Password}
       #Primary upstream DNS provider. it must be the static IP of Cloudflared container
       DNS1: '172.28.1.1#5053'
       # Secondary upstream DNS provider, default is Cloudflare DNS (1.1.1.1)


### PR DESCRIPTION
This seems to resolve the warning during start: `WARNING: The password variable is not set. Defaulting to a blank string.`
It does not change anything in the existing environment, but it might solve the problem with the new installation.